### PR TITLE
added s3_presigned_url endpoint capability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "behavioralsignals"
-version = "0.1.1"
+version = "0.2.0"
 description = "Python SDK for Behavioral Signals API"
 readme = "README.md"
 authors = []

--- a/src/behavioralsignals/base.py
+++ b/src/behavioralsignals/base.py
@@ -40,6 +40,7 @@ class BaseClient:
         path: str,
         method: str = "GET",
         data: Optional[dict] = None,
+        json: Optional[dict] = None,
         headers: Optional[dict] = None,
         files: Optional[dict] = None,
     ):
@@ -55,7 +56,7 @@ class BaseClient:
             )
         elif method == "POST":
             response = self.session.post(
-                url, headers=headers, data=data, files=files, timeout=self.config.timeout
+                url, headers=headers, data=data, files=files, json=json, timeout=self.config.timeout
             )
         else:
             raise ValueError(f"Unsupported method: {method}")

--- a/src/behavioralsignals/base.py
+++ b/src/behavioralsignals/base.py
@@ -46,6 +46,8 @@ class BaseClient:
         url = self.config.api_url + "/" + path
         if headers is None:
             headers = self._get_default_headers()
+        else:
+            headers = {**self._get_default_headers(), **headers}
 
         if method == "GET":
             response = self.session.get(

--- a/src/behavioralsignals/behavioral.py
+++ b/src/behavioralsignals/behavioral.py
@@ -81,24 +81,25 @@ class Behavioral(BaseClient):
         # Use provided name or default to filename
         job_name = params.name
 
-        data = {
+        payload = {
             "url": params.url,
             "name": job_name,
             "embeddings": params.embeddings
         }
-        headers = {"content-type": "application/x-www-form-urlencoded"}
 
         if params.meta:
-            data["meta"] = params.meta
+            payload["meta"] = params.meta
 
-        data = self._send_request(
+        headers = {"content-type": "application/json"}
+
+        response = self._send_request(
             path=f"clients/{self.config.cid}/processes/s3-presigned-url",
             method="POST",
-            data=data,
+            json=payload,
             headers=headers
         )
 
-        return ProcessItem(**data)
+        return ProcessItem(**response)
 
     def list_processes(
         self,

--- a/src/behavioralsignals/behavioral.py
+++ b/src/behavioralsignals/behavioral.py
@@ -9,6 +9,7 @@ from .models import (
     ResultResponse,
     StreamingOptions,
     AudioUploadParams,
+    S3UrlUploadParams,
     ProcessListParams,
     ProcessListResponse,
     StreamingResultResponse,
@@ -54,6 +55,48 @@ class Behavioral(BaseClient):
                 files=files,
                 data=data,
             )
+
+        return ProcessItem(**data)
+
+    def upload_s3_presigned_url(
+        self,
+        url: str,
+        name: Optional[str] = None,
+        embeddings: bool = False,
+        meta: Optional[str] = None,
+    ) -> ProcessItem:
+        """Uploads an S3 presigned url pointing to an audio file and returns the process item.
+
+        Args:
+            url (str): The S3 presigned url.
+            name (str, optional): Optional name for the job request. Defaults to filename.
+            embeddings (bool): Whether to include speaker and behavioral embeddings. Defaults to False.
+            meta (str, optional): Metadata json containing any extra user-defined metadata.
+        Returns:
+            ProcessItem: The process item containing details about the submitted process.
+        """
+        # Create and validate parameters
+        params = S3UrlUploadParams(url=url, name=name, embeddings=embeddings, meta=meta)
+
+        # Use provided name or default to filename
+        job_name = params.name
+
+        data = {
+            "url": params.url,
+            "name": job_name,
+            "embeddings": params.embeddings
+        }
+        headers = {"content-type": "application/x-www-form-urlencoded"}
+
+        if params.meta:
+            data["meta"] = params.meta
+
+        data = self._send_request(
+            path=f"clients/{self.config.cid}/processes/s3-presigned-url",
+            method="POST",
+            data=data,
+            headers=headers
+        )
 
         return ProcessItem(**data)
 

--- a/src/behavioralsignals/deepfakes.py
+++ b/src/behavioralsignals/deepfakes.py
@@ -81,24 +81,25 @@ class Deepfakes(BaseClient):
         # Use provided name or default to filename
         job_name = params.name
 
-        data = {
+        payload = {
             "url": params.url,
             "name": job_name,
             "embeddings": params.embeddings
         }
-        headers = {"content-type": "application/x-www-form-urlencoded"}
 
         if params.meta:
-            data["meta"] = params.meta
+            payload["meta"] = params.meta
 
-        data = self._send_request(
+        headers = {"content-type": "application/json"}
+
+        response = self._send_request(
             path=f"detection/clients/{self.config.cid}/processes/s3-presigned-url",
             method="POST",
-            data=data,
+            json=payload,
             headers=headers
         )
 
-        return ProcessItem(**data)
+        return ProcessItem(**response)
 
     def list_processes(
         self,

--- a/src/behavioralsignals/models.py
+++ b/src/behavioralsignals/models.py
@@ -80,6 +80,27 @@ class AudioUploadParams(BaseModel):
         return v
 
 
+class S3UrlUploadParams(BaseModel):
+    url: str = Field(..., description="The S3 presigned url containing the audio")
+    name: Optional[str] = Field(None, description="Optional name for the job request")
+    embeddings: bool = Field(
+        False, description="Whether to include speaker and behavioral embeddings in the result"
+    )
+    meta: Optional[str] = Field(
+        None, description="Metadata json containing any extra user-defined metadata"
+    )
+
+    @field_validator("meta")
+    @classmethod
+    def validate_meta_json(cls, v):
+        if v is not None:
+            try:
+                json.loads(v)
+            except json.JSONDecodeError:
+                raise ValueError("meta must be valid JSON string")
+        return v
+
+
 class ProcessItem(BaseModel):
     """Individual process in the list"""
 


### PR DESCRIPTION
## Changes

* Added new methods to behavioral/deepfakes clients for processing s3 singed urls

## How to QA

1. Create a pre-signed url on any S3 bucket
2. Run the following:

```shell
from behavioralsignals import Client

client = Client(YOUR_CID, YOUR_API_KEY)

response = client.behavioral.upload_s3_presigned_url(url="presigned-s3-url")
output = client.behavioral.get_result(pid=response.pid)

response = client.deepfakes.upload_s3_presigned_url(url="presigned-s3-url")
output = client.deepfakes.get_result(pid=response.pid)
```

